### PR TITLE
Improvements for calendar in version 0.28

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,11 +53,6 @@ jobs:
         with:
           ruby-version: ${{ env.RUBY_VERSION }}
           bundler-cache: true
- 
-      - uses: actions/download-artifact@v3
-        with:
-          name: workspace
-          path: /tmp
 
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,6 +38,16 @@ jobs:
       - uses: nanasess/setup-chromedriver@v2
         with:
           chromedriver-version: 119.0.6045.105
+      
+      - name: List Chrome
+        run: apt list --installed | grep chrome
+      
+      - name: Remove Chrome
+        run: sudo apt remove google-chrome-stable
+      
+      - uses: browser-actions/setup-chrome@v1
+        with:
+            chrome-version: 119.0.6045.105
 
       - uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,6 +53,11 @@ jobs:
         with:
           ruby-version: ${{ env.RUBY_VERSION }}
           bundler-cache: true
+ 
+      - uses: actions/download-artifact@v3
+        with:
+          name: workspace
+          path: /tmp
 
       - uses: actions/setup-node@v3
         with:
@@ -84,3 +89,9 @@ jobs:
         uses: codecov/codecov-action@v3
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: screenshots
+          path: ./spec/decidim_dummy_app/tmp/screenshots

--- a/app/packs/src/decidim/calendar/calendar.js
+++ b/app/packs/src/decidim/calendar/calendar.js
@@ -69,6 +69,7 @@ const calendar = new Calendar(calendarEl, {
   plugins: [interactionPlugin, dayGridPlugin, timeGridPlugin, listPlugin],
   initialView: getInitialView(),
   dayMaxEvents: 3,
+  contentHeight: 'auto',
   locale: currentLocale,
   firstDay: calendarEl.dataset.hasOwnProperty("firstday") // eslint-disable-line no-prototype-builtins
     ? parseInt(calendarEl.dataset.firstday)

--- a/app/packs/src/decidim/calendar/calendar.js
+++ b/app/packs/src/decidim/calendar/calendar.js
@@ -69,7 +69,7 @@ const calendar = new Calendar(calendarEl, {
   plugins: [interactionPlugin, dayGridPlugin, timeGridPlugin, listPlugin],
   initialView: getInitialView(),
   dayMaxEvents: 3,
-  contentHeight: 'auto',
+  contentHeight: "auto",
   locale: currentLocale,
   firstDay: calendarEl.dataset.hasOwnProperty("firstday") // eslint-disable-line no-prototype-builtins
     ? parseInt(calendarEl.dataset.firstday)

--- a/app/presenters/decidim/calendar/event_presenter.rb
+++ b/app/presenters/decidim/calendar/event_presenter.rb
@@ -99,7 +99,9 @@ module Decidim
       def hour
         return nil if start.is_a?(Date) || all_day?
 
-        start.strftime("%H:%M")
+        format = Decidim::Calendar.calendar_options[:hour12] ? "%I:%M %p" : "%H:%M"
+
+        start.strftime(format)
       end
     end
   end

--- a/spec/system/admin/external_events_spec.rb
+++ b/spec/system/admin/external_events_spec.rb
@@ -76,8 +76,8 @@ describe "manage external events", type: :system do
       start_time = Time.current
       end_time = 2.days.from_now
 
-      fill_in "external_event[start_at]", with: start_time.strftime
-      fill_in "external_event[end_at]", with: end_time.strftime
+      fill_in "external_event[start_at]", with: start_time
+      fill_in "external_event[end_at]", with: end_time
 
       within ".edit_event" do
         fill_in_i18n(

--- a/spec/system/admin/external_events_spec.rb
+++ b/spec/system/admin/external_events_spec.rb
@@ -23,8 +23,8 @@ describe "manage external events", type: :system do
       start_time = Time.current
       end_time = 2.days.from_now
 
-      fill_in "external_event[start_at]", with: start_time.strftime("%Y-%m-%dT%H:%M")
-      fill_in "external_event[end_at]", with: end_time.strftime("%Y-%m-%dT%H:%M")
+      fill_in "external_event[start_at]", with: start_time
+      fill_in "external_event[end_at]", with: end_time
 
       within ".new_event" do
         fill_in_i18n(
@@ -76,8 +76,8 @@ describe "manage external events", type: :system do
       start_time = Time.current
       end_time = 2.days.from_now
 
-      fill_in "external_event[start_at]", with: start_time.strftime("%Y-%m-%dT%H:%M")
-      fill_in "external_event[end_at]", with: end_time.strftime("%Y-%m-%dT%H:%M")
+      fill_in "external_event[start_at]", with: start_time.strftime
+      fill_in "external_event[end_at]", with: end_time.strftime
 
       within ".edit_event" do
         fill_in_i18n(

--- a/spec/system/admin/external_events_spec.rb
+++ b/spec/system/admin/external_events_spec.rb
@@ -19,12 +19,13 @@ describe "manage external events", type: :system do
       end
     end
 
+    
     it "create a new external event" do
       start_time = Time.current
       end_time = 2.days.from_now
 
-      fill_in "external_event[start_at]", with: start_time.strftime("%Y-%m-%dT%H:%M")
-      fill_in "external_event[end_at]", with: end_time.strftime("%Y-%m-%dT%H:%M")
+      fill_in "external_event[start_at]", with: start_time.strftime("%m/%d/%Y, %I:%M %p")
+      fill_in "external_event[end_at]", with: end_time.strftime("%m/%d/%Y, %I:%M %p")
 
       within ".new_event" do
         fill_in_i18n(
@@ -40,6 +41,8 @@ describe "manage external events", type: :system do
         find("*[type=submit]").click
       end
 
+      puts start_time.strftime("%m/%d/%Y, %I:%M %p")
+      puts end_time.strftime("%m/%d/%Y, %I:%M %p")
       expect(page).to have_admin_callout("successfully")
 
       within ".table-list" do

--- a/spec/system/admin/external_events_spec.rb
+++ b/spec/system/admin/external_events_spec.rb
@@ -19,13 +19,12 @@ describe "manage external events", type: :system do
       end
     end
 
-    
     it "create a new external event" do
       start_time = Time.current
       end_time = 2.days.from_now
 
-      fill_in "external_event[start_at]", with: start_time.strftime("%m/%d/%Y, %I:%M %p")
-      fill_in "external_event[end_at]", with: end_time.strftime("%m/%d/%Y, %I:%M %p")
+      fill_in "external_event[start_at]", with: start_time.strftime("%Y-%m-%dT%H:%M")
+      fill_in "external_event[end_at]", with: end_time.strftime("%Y-%m-%dT%H:%M")
 
       within ".new_event" do
         fill_in_i18n(
@@ -41,8 +40,6 @@ describe "manage external events", type: :system do
         find("*[type=submit]").click
       end
 
-      puts start_time.strftime("%m/%d/%Y, %I:%M %p")
-      puts end_time.strftime("%m/%d/%Y, %I:%M %p")
       expect(page).to have_admin_callout("successfully")
 
       within ".table-list" do


### PR DESCRIPTION
🎩 What? Why?
Two issues to improve:

 Times on the calendar are displayed in 24 hour format even when system preference is for am/pm format.

 Responsive CSS framework is currently working for small screens, as per the 'month view'.

📌 Related Issues
#176 on [gpc decidim](https://github.com/Green-Party-of-Canada-Members/gpc-decidim/issues/176)

📷 Screenshots

♥️ Thank you!